### PR TITLE
Set docker to use default libreadline8 & dev pkg.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get install --no-install-recommends \
 	'ruby' \
 	'bc' \
 	'htop' \
-    'libreadline7-dev' -y \
+    'libreadline-dev' -y \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/


### PR DESCRIPTION
The latest debian distro comes with a pre-installed libreadline8 and libreadline7 for some reason doesn't exist within the pkg repos. All that's actually needed for development with libreadline is the libreadline-dev package to be installed.